### PR TITLE
Added support for other types of compression

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -18,6 +18,14 @@ cd $1
 while read url; do
   if [ -n "$url" ]; then # incase ensure_newline_at_eof_on_save is enabled
     echo Vendoring $url | indent
-    curl -L --silent $url | tar xz
+
+    extension="${url##*.}" # http://stackoverflow.com/q/965053
+    flag="-z" # by default use gz
+    if [ "$extension" == "xz" ]; then flag="--xz"
+    elif [ "$extension" == "bz2" ]; then flag="--bzip2"
+    elif [ "$extension" == "tar" ]; then flag=""  # no compression
+    fi
+
+    curl -L --silent $url | tar x $flag
   fi
 done < .vendor_urls


### PR DESCRIPTION
I needed bz2 compression for a file, so decided to add bz2, xz, and no compression.
if a file is named weirdly it'll use gzip compression by default
